### PR TITLE
Testing PR that resolves $ref in inputSchemas

### DIFF
--- a/handlers/tools.ts
+++ b/handlers/tools.ts
@@ -18,9 +18,10 @@ const EchoSchema = z.object({
   message: z.string().describe("Message to echo back"),
 });
 
+const number = z.number().describe("A number to add");
 const AddSchema = z.object({
-  a: z.number().describe("First number"),
-  b: z.number().describe("Second number"),
+  a: number,
+  b: number
 });
 
 const GetCurrentTimeSchema = z.object({
@@ -45,18 +46,21 @@ const AnnotatedResponseSchema = z.object({
   includeMetadata: z.boolean().default(true).describe("Whether to include metadata"),
 });
 
+const address =  z.object({
+        street: z.string().describe("Street address"),
+        city: z.string().describe("City name"),
+        state: z.string().describe("State or province"),
+        zipCode: z.string().describe("ZIP or postal code"),
+        country: z.string().default("US").describe("Country code (ISO 3166-1 alpha-2)"),
+    }).describe("Address details");
+
 // Testing Tools
 const ComplexOrderSchema = z.object({
   customerName: z.string().describe("Full customer name for the order"),
   customerTaxId: z.string().describe("Tax identification number (e.g., 123-45-6789)"),
   customerEmail: z.string().email().describe("Customer's email address for notifications"),
-  shippingAddress: z.object({
-    street: z.string().describe("Street address"),
-    city: z.string().describe("City name"),
-    state: z.string().describe("State or province"),
-    zipCode: z.string().describe("ZIP or postal code"),
-    country: z.string().default("US").describe("Country code (ISO 3166-1 alpha-2)"),
-  }).describe("Shipping address details"),
+  billingAddress: address,
+  shippingAddress: address,
   items: z.array(z.object({
     productName: z.string().describe("Name of the product"),
     productSku: z.string().describe("Product SKU or identifier"),


### PR DESCRIPTION
See https://github.com/modelcontextprotocol/inspector/pull/889

* In tools.ts
  - modified AddSchema
    - tests simple primitive refs
    - extracted z.number() to a variable that is referenced for a and b properties
  - modified ComplexOrderSchema
    - tested object refs
    - extracted shipping address properties to address variable
    - referenced address from shippingAddress property
    - added billing address property that references address

### Simple primitive refs
<img width="1624" height="1031" alt="Screenshot 2025-10-30 at 10 35 44 AM" src="https://github.com/user-attachments/assets/bf7f76d6-ecbe-4931-8ac3-1c6ab0a5c821" />

### Complex object refs
<img width="807" height="817" alt="Screenshot 2025-10-30 at 10 42 06 AM" src="https://github.com/user-attachments/assets/6206a456-e50d-4c7c-a8c6-f9a571401dcc" />
<img width="743" height="723" alt="Screenshot 2025-10-30 at 10 42 57 AM" src="https://github.com/user-attachments/assets/ea1661c6-cb5b-4c04-b749-613e78c538af" />
