### PR TITLE
Testing PR that enhances resolution and enum handling in anyOf schemas

### DIFF
--- a/handlers/tools.ts
+++ b/handlers/tools.ts
@@ -109,6 +109,23 @@ const EnumDropdownTestSchema = z.object({
   colorScheme: z.enum(["light", "dark", "auto", "high-contrast", "solarized-light", "solarized-dark", "monokai", "dracula"]).default("auto").describe("UI color scheme preference"),
 }).describe("Tool to test enum dropdown rendering in Inspector UI (https://github.com/modelcontextprotocol/inspector/issues/755, https://github.com/modelcontextprotocol/inspector/pull/823)");
 
+const PersonSchema = z.object({
+  firstName: z.string().describe("Person's first name"),
+  lastName: z.string().describe("Person's last name"),
+}).describe("A person object");
+
+const JSONRefTestSchema = z.object({
+  husband: PersonSchema,
+  wife: PersonSchema,
+}).describe("Tool to test JSON schema $ref support. Requires husband and wife Person objects.");
+
+const UserRoleSchema = z.enum(["customer", "admin", "moderator"]);
+
+const UserFilterSchema = z.object({
+  role: UserRoleSchema.nullable().describe("Filter by role"),
+  is_active: z.union([z.boolean(), z.null()]).describe("Filter by active status"),
+});
+
 const LongDescriptionTestSchema = z.object({
   message: z.string().describe("A simple message to echo back"),
 }).describe(`Tool to test long description rendering improvements (https://github.com/modelcontextprotocol/inspector/pull/823)
@@ -166,6 +183,8 @@ export enum ToolName {
   UNION_TYPE_TEST = "unionTypeTest",
   ENUM_DROPDOWN_TEST = "enumDropdownTest",
   LONG_DESCRIPTION_TEST = "longDescriptionTest",
+  JSON_REF_TEST = "jsonRefTest",
+  USER_FILTER_TEST = "userFilterTest",
 }
 
 // Helper functions
@@ -274,6 +293,21 @@ export function setupToolHandlers(server: Server) {
         name: ToolName.LONG_DESCRIPTION_TEST,
         description: LongDescriptionTestSchema.description,
         inputSchema: zodToJsonSchema(LongDescriptionTestSchema) as ToolInput,
+      },
+      {
+        name: ToolName.JSON_REF_TEST,
+        description: "Tests JSON schema $ref support with nested Person objects",
+        inputSchema: zodToJsonSchema(JSONRefTestSchema, {
+          definitions: { Person: PersonSchema },
+        }) as ToolInput,
+      },
+      {
+        name: ToolName.USER_FILTER_TEST,
+        description: "Tests JSON schema with $ref to $defs and nullable types",
+        inputSchema: zodToJsonSchema(UserFilterSchema, {
+          definitions: { UserRole: UserRoleSchema },
+          definitionPath: "$defs",
+        }) as ToolInput,
       },
     ];
 
@@ -503,6 +537,30 @@ export function setupToolHandlers(server: Server) {
           {
             type: "text",
             text: `✅ Long description rendering test completed!\n\nYour message: "${validatedArgs.message}"\n\nDid you notice the following improvements in the Inspector UI?\n\n✓ LIST VIEW (left pane):\n  • Tool description truncated after 3 lines with ellipsis\n  • Clean, scannable list without overwhelming detail\n\n✓ DETAIL VIEW (right pane):\n  • Description respects newlines and indentation (whitespace-pre-wrap)\n  • Scrollable if content exceeds max-height of 12rem (max-h-48)\n  • Horizontal rule separating description from inputs/outputs\n\nThese improvements from PR #823 make the Inspector more usable for tools with detailed documentation!`,
+          },
+        ],
+      };
+    }
+
+    if (name === ToolName.JSON_REF_TEST) {
+      const validatedArgs = JSONRefTestSchema.parse(args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ JSON ref test completed!\n\nHusband: ${validatedArgs.husband.firstName} ${validatedArgs.husband.lastName}\nWife: ${validatedArgs.wife.firstName} ${validatedArgs.wife.lastName}\n\nThis tool tested if the input schema correctly uses $ref for the Person object.`,
+          },
+        ],
+      };
+    }
+
+    if (name === ToolName.USER_FILTER_TEST) {
+      const validatedArgs = UserFilterSchema.parse(args);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `User Filter Test: role=${validatedArgs.role}, is_active=${validatedArgs.is_active}`,
           },
         ],
       };

--- a/handlers/tools.ts
+++ b/handlers/tools.ts
@@ -201,15 +201,15 @@ export enum ToolName {
 function formatAsTable(data: any): string {
   if (Array.isArray(data)) {
     if (data.length === 0) return "Empty array";
-    
+
     const headers = Object.keys(data[0]);
     let table = headers.join(" | ") + "\n";
     table += headers.map(() => "---").join(" | ") + "\n";
-    
+
     for (const row of data) {
       table += headers.map(h => String(row[h] || "")).join(" | ") + "\n";
     }
-    
+
     return table;
   } else if (typeof data === 'object' && data !== null) {
     let table = "Key | Value\n--- | ---\n";
@@ -218,14 +218,14 @@ function formatAsTable(data: any): string {
     }
     return table;
   }
-  
+
   return String(data);
 }
 
 function formatAsYaml(data: any): string {
   function yamlify(obj: any, indent = 0): string {
     const spaces = "  ".repeat(indent);
-    
+
     if (Array.isArray(obj)) {
       return obj.map(item => `${spaces}- ${yamlify(item, 0)}`).join("\n");
     } else if (typeof obj === 'object' && obj !== null) {
@@ -242,7 +242,7 @@ function formatAsYaml(data: any): string {
       return String(obj);
     }
   }
-  
+
   return yamlify(data);
 }
 
@@ -360,7 +360,7 @@ export function setupToolHandlers(server: Server) {
     if (name === ToolName.GET_CURRENT_TIME) {
       const validatedArgs = GetCurrentTimeSchema.parse(args);
       const now = new Date();
-      
+
       let timeString: string;
       if (validatedArgs.timezone) {
         try {
@@ -371,7 +371,7 @@ export function setupToolHandlers(server: Server) {
       } else {
         timeString = now.toLocaleString();
       }
-      
+
       return {
         content: [
           {
@@ -385,7 +385,7 @@ export function setupToolHandlers(server: Server) {
     if (name === ToolName.FORMAT_DATA) {
       const validatedArgs = FormatDataSchema.parse(args);
       let formatted: string;
-      
+
       switch (validatedArgs.format) {
         case "json":
           formatted = JSON.stringify(validatedArgs.data, null, 2);
@@ -399,7 +399,7 @@ export function setupToolHandlers(server: Server) {
         default:
           formatted = String(validatedArgs.data);
       }
-      
+
       return {
         content: [
           {
@@ -444,17 +444,17 @@ export function setupToolHandlers(server: Server) {
     if (name === ToolName.ANNOTATED_RESPONSE) {
       const validatedArgs = AnnotatedResponseSchema.parse(args);
       const { messageType, includeMetadata } = validatedArgs;
-      
+
       const content = [];
-      
+
       const priorities = { info: 0.5, warning: 0.7, error: 1.0, success: 0.6 };
-      const audiences = { 
-        info: ["user", "assistant"], 
-        warning: ["user"], 
-        error: ["user", "assistant"], 
-        success: ["user"] 
+      const audiences = {
+        info: ["user", "assistant"],
+        warning: ["user"],
+        error: ["user", "assistant"],
+        success: ["user"]
       };
-      
+
       content.push({
         type: "text",
         text: `This is a ${messageType} message demonstrating annotations.`,
@@ -464,7 +464,7 @@ export function setupToolHandlers(server: Server) {
           messageType: messageType,
         },
       });
-      
+
       if (includeMetadata) {
         content.push({
           type: "text",
@@ -476,7 +476,7 @@ export function setupToolHandlers(server: Server) {
           },
         });
       }
-      
+
       return { content };
     }
 
@@ -583,7 +583,8 @@ export function setupToolHandlers(server: Server) {
           },
         ],
       };
-      
+    }
+
     if (name === ToolName.ELICITATION_ALL_OPTIONAL) {
       ElicitationAllOptionalSchema.parse(args);
 


### PR DESCRIPTION
See https://github.com/modelcontextprotocol/inspector/pull/901

* In tools.ts
  - added `jsonRefTest` to make sure refs handling still works
    - Added `JSONRefTestSchema` which requires two `PersonSchema` objects: `husband` and `wife`.
    - Updated the `ToolName` enum to include `JSON_REF_TEST`.
    - Updated `setupToolHandlers` to register the new tool in `ListToolsRequestSchema`. The `inputSchema` is generated using `zodToJsonSchema` with the `definitions` option, ensuring that the resulting JSON schema uses `$ref` for the `Person` objects.
    - Added a handler for the `jsonRefTest` tool in `CallToolRequestSchema` that parses the arguments and returns a success message identifying the husband and wife.
  - Added a new tool `userFilterTest` to `handlers/tools.ts` along with its Zod input schema designed to yield a specific JSON schema with `$ref`, `$defs`, and nullable types.
    - Defined `UserRoleSchema` as a Zod enum.
    - Defined `UserFilterSchema` with `role` (referencing `UserRoleSchema`) and `is_active` (boolean), both nullable.
    - Added `USER_FILTER_TEST` to `ToolName` enum.
    - Registered the `userFilterTest` tool in `setupToolHandlers` using `zodToJsonSchema` with `definitions` and `definitionPath: "$defs"` to match the requested output format.
    - Added a basic handler for `userFilterTest` in `CallToolRequestSchema`.